### PR TITLE
Added support to import ACL's

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,64 @@ ermrestUtils.importData(configuration).then(function(data) {
 });
 ```
 
+### Import ACL's explicitly
+
+To import acl's explicitly you can call the `importACLs` method and pass a configuration object. The format for the configuration is as follows
+
+```js
+var dataUtils = require('ErmrestDataUtils');
+
+var config = {
+	url: "https://dev.isrd.isi.edu/ermrest",  //Ermrest API url
+	authCookie: "ermrest_cookie;", // Ermrest Authentication cookie to create data
+	"catalog": {
+        "id": catalogId,
+        "acls": {
+            "enumerate": ["*",] // everybody can read!
+        },
+        "schemas": {
+            "product": {
+                "acls": {
+                    "enumerate": ["*"]
+                },
+                "tables": {
+                    "accommodation": {
+                        "acls": {
+                            "select": ["userid1", "userid2"]
+                        },
+                        "columns": {
+                            "id": {
+                                "acls": {
+                                    "select": []
+                                }
+                            },
+                            "title": {
+                                "acls": {
+                                    "select": ["userid1"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+dataUtils.importACLS(config).then(function() {
+    console.log("Acls imported with catalogId " + catalogId);
+    console.log("Please remember to clean up the catalog.");
+    process.exit(0);
+}, function(err) {
+    console.log("Unable to import acls");
+    console.dir(err);
+    process.exit(1);
+});
+```
+
+You can skip acls on catalog level or schema level or table level. The acls object is not mandatory and all other nested objects(schemas, tables, columns) are optional too.
+
+
 ### Cleanup
 
 To delete the stuff created by the testcases, you should call `tear` with the same configuration that you provided for import. This will delete only that data which was created by the import function and leave other stuff intact. To allow delete, you need to set cleanup as true in your configuration as mentioned above.

--- a/demo/importDemo.js
+++ b/demo/importDemo.js
@@ -4,20 +4,19 @@ var configuration = {
     setup: {
         "catalog": {
             "acls": {
-                "write": ["*"] // everybody can write!
             }
         },
         "schema": {
             "name": "product",   
             "createNew": true,  
-            "path": "schema/product.json"  
+            "path": "demo/schema/product.json"  
         },
         "tables": {
             "createNew": true
         },
         "entities": {
             "createNew": true,
-            "path": "data/product"  
+            "path": "demo/data/product"  
         }
     },
     url: process.env.ERMREST_URL,
@@ -27,7 +26,61 @@ var configuration = {
 dataUtils.importData(configuration).then(function(data) {
     console.log("Data imported with catalogId " + data.catalogId);
     console.log("Please remember to clean up the catalog.");
+    importAcls(data.catalogId);
 }, function(err) {
     console.log("Unable to import data");
     console.dir(err);
 });
+
+
+var importAcls = function(catalogId) {
+    var config = {
+        setup: {
+            "catalog": {
+                "id": catalogId,
+                "acls": {
+                    "enumerate": ["*"] // everybody can read!
+                },
+                "schemas": {
+                    "product": {
+                        "acls": {
+                            "enumerate": ["*"]
+                        },
+                        "tables": {
+                            "accommodation": {
+                                "acls": {
+                                    "select": ["userid1", "userid2"]
+                                },
+                                "columns": {
+                                    "id": {
+                                        "acls": {
+                                            "select": []
+                                        }
+                                    },
+                                    "title": {
+                                        "acls": {
+                                            "select": ["userid1"]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        url: process.env.ERMREST_URL,
+        authCookie: process.env.AUTH_COOKIE
+    };
+
+    dataUtils.importACLS(config).then(function() {
+        console.log("Acls imported with catalogId " + catalogId);
+        console.log("Please remember to clean up the catalog.");
+        process.exit(0);
+    }, function(err) {
+        console.log("Unable to import acls");
+        console.dir(err);
+        process.exit(1);
+    });
+
+};

--- a/model/catalog.js
+++ b/model/catalog.js
@@ -42,21 +42,25 @@ Catalog.prototype.create = function() {
 	return defer.promise;
 };
 
- /**
+Catalog.prototype.addACLs = function(acls) {
+	return Catalog.addACLs(this.url, this.id, acls);
+};
+
+/**
  * @param {acls} An array of acl objects
  * @returns {Promise} Returns a promise.
  * @desc
  * An asynchronous method that returns a promise. If fulfilled, it adds the acls for the catalog.
  */
-Catalog.prototype.addACLs = function(acls) {
-	var defer = Q.defer(), self = this;
-	if (!this.id) return defer.reject("No Id set : addACL catalog function"), defer.promise;
+Catalog.addACLs = function(url, id, acls) {
+	var defer = Q.defer();
+	if (!id) return defer.reject("No Id set : addACL catalog function"), defer.promise;
 	if (!acls || acls.length == 0) defer.resolve();
 
 	var promises = [];
 
 	for (var acl in acls) {
-		promises.push(self.addACL(acl, acls[acl]));
+		promises.push(Catalog.addACL(url, id, acl, acls[acl]));
 	}
 
 	Q.all(promises).then(function() {
@@ -66,7 +70,7 @@ Catalog.prototype.addACLs = function(acls) {
 	});
 
 	return defer.promise;
-}
+};
 
 /**
  * @param {string} key the key of the ACL.
@@ -75,14 +79,15 @@ Catalog.prototype.addACLs = function(acls) {
  * @desc
  * An asynchronous method that returns a promise. If fulfilled, it adds the acl for the catalog.
  */
-Catalog.prototype.addACL = function(aclKey, value) {
-	var defer = Q.defer(), self = this;
-	if (!this.id || (typeof aclKey !== 'string')) return defer.reject("No Id or ACL set : addACL catalog function"), defer.promise;
+
+Catalog.addACL = function(url, id, aclKey, value) {
+	var defer = Q.defer();
+	if (!id || (typeof aclKey !== 'string')) return defer.reject("No Id or ACL set : addACL catalog function"), defer.promise;
 	
-	http.put(this.url + '/catalog/' + this.id + "/acl/" + aclKey,  value).then(function(response) {
-		defer.resolve(self);
+	http.put(url + '/catalog/' + id + "/acl/" + aclKey,  value).then(function(response) {
+		defer.resolve();
 	}, function(err) {
-		defer.reject(err, self);
+		defer.reject(err);
 	});
 
 	return defer.promise;

--- a/model/column.js
+++ b/model/column.js
@@ -1,0 +1,61 @@
+var Q = require('q');
+var http = require('request-q');
+var utils = require('./utils.js');
+
+/* @namespace Column
+ * @desc
+ * The Column module for the ERMrest API
+ * service.
+ * @constructor
+ */
+var Column = function() {};
+
+/**
+ * @param {acls} An array of acl objects
+ * @returns {Promise} Returns a promise.
+ * @desc
+ * An asynchronous method that returns a promise. If fulfilled, it adds the acls for the Column.
+ */
+Column.addACLs = function(url, catalogId, schemaName, tableName, columnName, acls) {
+	var defer = Q.defer();
+	if (!catalogId) return defer.reject("No catalogId set : addACL Column function"), defer.promise;
+	if (!acls || acls.length == 0) defer.resolve();
+
+	var promises = [];
+
+	for (var acl in acls) {
+		promises.push(Column.addACL(url, catalogId, schemaName, tableName, columnName, acl, acls[acl]));
+	}
+
+	Q.all(promises).then(function() {
+		defer.resolve();
+	}, function(err) {
+		defer.reject(err);
+	});
+
+	return defer.promise;
+};
+
+/**
+ * @param {string} key the key of the ACL.
+ * @param {string[]} value the array of users that have that ACL (will be sent to ermret without any change).
+ * @returns {Promise} Returns a promise.
+ * @desc
+ * An asynchronous method that returns a promise. If fulfilled, it adds the acl for the Column.
+ */
+
+Column.addACL = function(url, catalogId, schemaName, tableName, columnName, aclKey, value) {
+	var defer = Q.defer();
+	if (!catalogId || (typeof aclKey !== 'string')) return defer.reject("No catalogId or ACL set : addACL Column function"), defer.promise;
+	
+	http.put(url + '/catalog/' + catalogId + "/schema/" + utils._fixedEncodeURIComponent(schemaName) + "/table/" + utils._fixedEncodeURIComponent(tableName) + "/column/" + utils._fixedEncodeURIComponent(columnName) + "/acl/" + aclKey,  value).then(function(response) {
+		defer.resolve();
+	}, function(err) {
+		defer.reject(err);
+	});
+
+	return defer.promise;
+};
+
+
+module.exports = Column;

--- a/model/table.js
+++ b/model/table.js
@@ -105,6 +105,53 @@ Table.prototype.addForeignKey = function(foreignKey) {
 };
 
 /**
+ * @param {acls} An array of acl objects
+ * @returns {Promise} Returns a promise.
+ * @desc
+ * An asynchronous method that returns a promise. If fulfilled, it adds the acls for the table.
+ */
+Table.addACLs = function(url, catalogId, schemaName, tableName, acls) {
+	var defer = Q.defer();
+	if (!catalogId) return defer.reject("No catalogId set : addACL Table function"), defer.promise;
+	if (!acls || acls.length == 0) defer.resolve();
+
+	var promises = [];
+
+	for (var acl in acls) {
+		promises.push(Table.addACL(url, catalogId, schemaName, tableName, acl, acls[acl]));
+	}
+
+	Q.all(promises).then(function() {
+		defer.resolve();
+	}, function(err) {
+		defer.reject(err);
+	});
+
+	return defer.promise;
+};
+
+/**
+ * @param {string} key the key of the ACL.
+ * @param {string[]} value the array of users that have that ACL (will be sent to ermret without any change).
+ * @returns {Promise} Returns a promise.
+ * @desc
+ * An asynchronous method that returns a promise. If fulfilled, it adds the acl for the table.
+ */
+
+Table.addACL = function(url, catalogId, schemaName, tableName, aclKey, value) {
+	var defer = Q.defer();
+	if (!catalogId || (typeof aclKey !== 'string')) return defer.reject("No catalogId or ACL set : addACL Table function"), defer.promise;
+	
+	http.put(url + '/catalog/' + catalogId + "/schema/" + utils._fixedEncodeURIComponent(schemaName) + "/table/" + utils._fixedEncodeURIComponent(tableName) + "/acl/" + aclKey,  value).then(function(response) {
+		defer.resolve();
+	}, function(err) {
+		defer.reject(err);
+	});
+
+	return defer.promise;
+};
+
+/**
  *
  * @desc
  * Not yet implemented.


### PR DESCRIPTION
This PR allows to import ACL's by defining it directly in your configuration or by explicitly calling the importAcls function. 

To import acl's explicitly you can call the `importACLs` method and pass a configuration object. The format for the configuration is as follows

```js
var dataUtils = require('ErmrestDataUtils');

var config = {
	url: "https://dev.isrd.isi.edu/ermrest",  //Ermrest API url
	authCookie: "ermrest_cookie;", // Ermrest Authentication cookie to create data
	"catalog": {
        "id": catalogId,
        "acls": {
            "enumerate": ["*",] // everybody can read!
        },
        "schemas": {
            "product": {
                "acls": {
                    "enumerate": ["*"]
                },
                "tables": {
                    "accommodation": {
                        "acls": {
                            "select": ["userid1", "userid2"]
                        },
                        "columns": {
                            "id": {
                                "acls": {
                                    "select": []
                                }
                            },
                            "title": {
                                "acls": {
                                    "select": ["userid1"]
                                }
                            }
                        }
                    }
                }
            }
        }
    }
};

dataUtils.importACLS(config).then(function() {
    console.log("Acls imported with catalogId " + catalogId);
    console.log("Please remember to clean up the catalog.");
    process.exit(0);
}, function(err) {
    console.log("Unable to import acls");
    console.dir(err);
    process.exit(1);
});
```

You can skip acls on catalog level or schema level or table level. The acls object is not mandatory and all other nested objects(schemas, tables, columns) are optional too.