### PR TITLE
Bulk Schema Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var configuration = {
 	{
 	    "catalog": { // required
 	        //"id": 1  //existing id of a catalog
-	        //"acls": {} 
+	        //"acls": {}
 	    },
 	    "schema": { // required
 	        "name": "product",
@@ -50,6 +50,38 @@ ermrestUtils.importData(configuration).then(function(data) {
 	console.log("Unable to import data");
 	console.dir(err);
 });
+```
+
+### Import Multiple Schemas
+If you want to create multiple schemas at once, you can use the following method with the given configuration structure.
+
+```javascript
+var configuration = {
+  setup: { // required
+    "catalog": { // (optional)
+      "id": "existing catalog id", // pass this if you want to use an existing catalog
+      "acls": {} // pas the list of acls that you want to add for the catalog
+    },
+    "schemas": { // list all the schemas that you want to create here
+      "schema name 1": {
+        "path": "path to the schema document file",
+        "entities": "the folder path from where the json for the entities will be picked for import"
+      },
+      ...
+    }
+  },
+  url: "ermrest url", //required
+  authCookie: "webauthn cookie" //required
+};
+
+var ermrestUtils = require('ermrest-data-utils');
+ermrestUtils.createSchemasAndEntities(configuration).then(function(data) {
+	console.log("Data imported with catalogId " + data.catalogId);
+}, function(err) {
+	console.log("Unable to import data");
+	console.dir(err);
+});
+
 ```
 
 ### Import ACL's explicitly

--- a/demo/importDemo.js
+++ b/demo/importDemo.js
@@ -4,26 +4,21 @@ var configuration = {
     setup: {
         "catalog": {
             "acls": {
+              "enumerate": ["*"]
             }
         },
-        "schema": {
-            "name": "product",   
-            "createNew": true,  
-            "path": "demo/schema/product.json"  
-        },
-        "tables": {
-            "createNew": true
-        },
-        "entities": {
-            "createNew": true,
-            "path": "demo/data/product"  
+        "schemas": {
+          "product": {
+            "path": "demo/schema/product.json",
+            "entities": "demo/data/product"
+          }
         }
     },
     url: process.env.ERMREST_URL,
     authCookie: process.env.AUTH_COOKIE
 };
 
-dataUtils.importData(configuration).then(function(data) {
+dataUtils.createSchemasAndEntities(configuration).then(function(data) {
     console.log("Data imported with catalogId " + data.catalogId);
     console.log("Please remember to clean up the catalog.");
     importAcls(data.catalogId);

--- a/import.js
+++ b/import.js
@@ -459,11 +459,13 @@ var createTables = function(schema) {
 			});
 			tables[k] = table;
 			tableNames.push(k);
+
+      // gather the table documents for creation
 			if (config.tables.createNew == true && (!schema.content.tables[k].exists || (config.tables.newTables.indexOf(k) != -1))) {
         if (!table.catalog.id || !table.schema.name || !table.name) {
           return defer.reject("No catalog or schema set : create table function"), defer.promise;
         }
-        tableDocs.push(table.create());
+        tableDocs.push(table.content);
       }
 		}
 

--- a/import.js
+++ b/import.js
@@ -690,9 +690,10 @@ exports.createSchemasAndEntities = function (settings) {
       defer.resolve({catalogId: catalog.id});
     }
   }).catch(function (err) {
-    console.log("catch error!");
+    console.log("encountered an error while bulk creation.");
     console.log(err);
-    defer.reject(err);
+    if (catalog && catalog.id) defer.reject({ catalogId: catalog.id });
+		else defer.reject(err || {});
   });
 
   return defer.promise;

--- a/import.js
+++ b/import.js
@@ -615,11 +615,9 @@ exports.createSchemasAndEntities = function (settings) {
   */
   var defer = Q.defer();
 
-  console.log("HERE WE GO!");
-
   var error = "";
   if (typeof settings.authCookie !== "string" && !settings.authCookie) {
-    error = "authCookie is missing";
+    error = "authCookie is missing.";
   } else if (!settings.setup) {
     error = "setup is missing.";
   } else if (!settings.setup.catalog) {
@@ -647,21 +645,17 @@ exports.createSchemasAndEntities = function (settings) {
 
   console.log("authCookie: ", settings.authCookie);
   http.get(config.url.replace('ermrest', 'authn') + "/session").then(function(response) {
-    console.log("Valid session found");
+    console.log("Valid session found.");
     // create catalog or use the existing
     return createCatalog(catalog);
   }).then(function () {
     // append all schemas together and send a request to create them
-    console.log("create catalog done");
     return createSchemas(catalog);
   }).then(function () {
-    console.log("create schemas done");
     return importCatalogEntities(catalog);
   }).then(function () {
-    console.log("create entities done");
     return createCatalogForeignKeys(catalog);
   }).then(function () {
-    console.log("create foreignkeys done");
     if (config.schemas) {
       defer.resolve({schemas: catalog.schemas, catalogId: catalog.id});
     } else {
@@ -695,6 +689,9 @@ function createSchemas(catalog) {
       schema: require(process.env.PWD + "/" + config.schemas[schemaName].path)
     });
 
+    if (schemaName != schema.name) {
+      return defer.reject("given schema name (" + schemaName + ") in configuraion is not the same as schema_name."), defer.promise;
+    }
 
     // create table objects in the schema (this removes foreignkey content)
     schema.tables = {};
@@ -755,7 +752,6 @@ function importCatalogEntities(catalog) {
   }
 
   Q.all(promises).then(function () {
-    console.log("entities created for the given schemas!");
     defer.resolve();
   }).catch(function (err) {
     defer.reject(err);
@@ -787,7 +783,7 @@ function createCatalogForeignKeys(catalog) {
 
   var url = schema.url + '/catalog/' + schema.catalog.id + "/schema/";
   http.post(url, fks).then(function (response) {
-    console.log(fks.length + " foreignkeys created for the given schemas!");
+    console.log(fks.length + " foreignkeys created for the given schemas.");
     defer.resolve();
   }).catch(function (err) {
     defer.reject(err);

--- a/model/catalog.js
+++ b/model/catalog.js
@@ -83,7 +83,7 @@ Catalog.addACLs = function(url, id, acls) {
 Catalog.addACL = function(url, id, aclKey, value) {
 	var defer = Q.defer();
 	if (!id || (typeof aclKey !== 'string')) return defer.reject("No Id or ACL set : addACL catalog function"), defer.promise;
-	
+
 	http.put(url + '/catalog/' + id + "/acl/" + aclKey,  value).then(function(response) {
 		defer.resolve();
 	}, function(err) {
@@ -102,7 +102,7 @@ Catalog.addACL = function(url, id, aclKey, value) {
 Catalog.prototype.remove = function() {
 	var defer = Q.defer(), self = this;
 	if (!this.id) return defer.reject("No Id set : remove catalog function"), defer.promise;
-	
+
 	http.delete(this.url + '/catalog/' + this.id).then(function() {
 		defer.resolve(self);
 	}, function(err) {
@@ -118,11 +118,11 @@ Catalog.prototype.remove = function() {
  * A synchronous method that sets the default schema on basis of current catalog schemas.
  */
 Catalog.prototype.setSchemas = function() {
-	var defaultSchema = null, schemas = this.content.schemas;	
+	var defaultSchema = null, schemas = this.content.schemas;
 	this.schemas = {};
 	for (var k in schemas) {
-		var schema = new Schema({ schema: schemas[k], catalog: this, name: schemas[k].schema_name });		
-		var annotations = schemas[k].annotations; 
+		var schema = new Schema({ schema: schemas[k], catalog: this, name: schemas[k].schema_name });
+		var annotations = schemas[k].annotations;
 
 		if (!defaultSchema && annotations != null && annotations['comment'] != null && annotations['comment'].contains('default')) {
 			defaultSchema = schema
@@ -132,7 +132,7 @@ Catalog.prototype.setSchemas = function() {
 
 		this.schemas[schema.name] = schema;
 	}
-	
+
 	if (defaultSchema == null) {
 		for (var k in schemas) {
 			var s = schemas[k];
@@ -145,7 +145,7 @@ Catalog.prototype.setSchemas = function() {
 			}
 			if (defaultSchema != null) break;
 		}
-		
+
 		if (defaultSchema == null) {
 			// get the first schema from the catalog
 			for (var k in schemas) {

--- a/model/schema.js
+++ b/model/schema.js
@@ -53,7 +53,7 @@ Schema.prototype.create = function(schemaName) {
 Schema.prototype.remove = function() {
 	var defer = Q.defer(), self = this;
 	if (!this.catalog.id || !this.name) return defer.reject("No Catalog or Name set: remove schema function"), defer.promise;
-	
+
 	http.delete(this.url + '/catalog/' + this.catalog.id + "/schema/" + utils._fixedEncodeURIComponent(this.name)).then(function() {
 		defer.resolve(self);
 	}, function(err) {
@@ -120,7 +120,7 @@ Schema.prototype.setDefaultTable = function() {
 			(table['annotations']['comment'].contains('exclude') || table['annotations']['comment'].contains('association'));
 		var nested = table['annotations'] != null && table['annotations']['comment'] != null &&
 			table['annotations']['comment'].contains('nested');
-		
+
 		if (!exclude && !nested) {
 			rootTables.push(table['table_name']);
 			if (table['annotations'] != null && table['annotations']['comment'] != null && table['annotations']['comment'].contains('default')) {
@@ -128,7 +128,7 @@ Schema.prototype.setDefaultTable = function() {
 			}
 		}
 	};
-	
+
 	if (defaultTable == null) defaultTable = tables[rootTables[0]];
 	this.defaultTable = defaultTable;
 	return this.defaultTable;
@@ -175,7 +175,7 @@ Schema.addACLs = function(url, catalogId, schemaName, acls) {
 Schema.addACL = function(url, catalogId, schemaName, aclKey, value) {
 	var defer = Q.defer();
 	if (!catalogId || (typeof aclKey !== 'string')) return defer.reject("No Id or ACL set : addACL Schema function"), defer.promise;
-	
+
 	http.put(url + '/catalog/' + catalogId + "/schema/" + utils._fixedEncodeURIComponent(schemaName) + "/acl/" + aclKey,  value).then(function(response) {
 		defer.resolve();
 	}, function(err) {

--- a/model/table.js
+++ b/model/table.js
@@ -20,6 +20,7 @@ var Table = function(options) {
 	this.name = this.content.table_name;
 	this.foreignKeys = this.content.foreign_keys || [];
 	this.content.schema_name = this.schema.name;
+  this.content.foreign_keys = [];
 	this.setTableParameters = function(name) {
 		this.content = {
 		  "comment": "",
@@ -33,6 +34,9 @@ var Table = function(options) {
 		};
 		this.name = name;
 	};
+
+  // add the system columns
+	this.addSystemColumsAndKeys();
 };
 
 Table.prototype.addSystemColumsAndKeys = function() {
@@ -64,31 +68,24 @@ Table.prototype.addSystemColumsAndKeys = function() {
  * An asynchronous method that returns a promise. If fulfilled, it creates a new table.
  */
 Table.prototype.create = function(timeout) {
-	// var self  = this;
+	var self  = this;
 
-	// if (!this.catalog.id || !this.schema.name || !this.name) return defer.reject("No catalog or schema set : create table function"), defer.promise;
+	if (!this.catalog.id || !this.schema.name || !this.name) return defer.reject("No catalog or schema set : create table function"), defer.promise;
 
-	this.content.schema_name = this.schema.name;
-	this.foreignKeys = this.content.foreign_keys;
-	this.content.foreign_keys = [];
+	setTimeout(function() {
 
-	this.addSystemColumsAndKeys();
+		http.post(self.url + '/catalog/' + self.catalog.id + "/schema/" + utils._fixedEncodeURIComponent(self.schema.name) + "/table", self.content).then(function(response) {
+			self.content = response.data;
+			self.name = self.content.table_name;
+			console.log("Table " + self.content.table_name + " created");
+			defer.resolve(self);
+		}, function(err) {
+			defer.reject(err, self);
+		});
 
-	// setTimeout(function() {
-  //
-	// 	http.post(self.url + '/catalog/' + self.catalog.id + "/schema/" + utils._fixedEncodeURIComponent(self.schema.name) + "/table", self.content).then(function(response) {
-	// 		self.content = response.data;
-	// 		self.name = self.content.table_name;
-	// 		console.log("Table " + self.content.table_name + " created");
-	// 		defer.resolve(self);
-	// 	}, function(err) {
-	// 		defer.reject(err, self);
-	// 	});
-  //
-	// }, timeout || 0);
-  //
-	// return defer.promise;
-	return this.content;
+	}, timeout || 0);
+
+	return defer.promise;
 };
 
 /**

--- a/model/table.js
+++ b/model/table.js
@@ -64,9 +64,9 @@ Table.prototype.addSystemColumsAndKeys = function() {
  * An asynchronous method that returns a promise. If fulfilled, it creates a new table.
  */
 Table.prototype.create = function(timeout) {
-	var defer = Q.defer(), self  = this;
+	// var self  = this;
 
-	if (!this.catalog.id || !this.schema.name || !this.name) return defer.reject("No catalog or schema set : create table function"), defer.promise;
+	// if (!this.catalog.id || !this.schema.name || !this.name) return defer.reject("No catalog or schema set : create table function"), defer.promise;
 
 	this.content.schema_name = this.schema.name;
 	this.foreignKeys = this.content.foreign_keys;
@@ -74,20 +74,21 @@ Table.prototype.create = function(timeout) {
 
 	this.addSystemColumsAndKeys();
 
-	setTimeout(function() {
-
-		http.post(self.url + '/catalog/' + self.catalog.id + "/schema/" + utils._fixedEncodeURIComponent(self.schema.name) + "/table", self.content).then(function(response) {
-			self.content = response.data;
-			self.name = self.content.table_name;
-			console.log("Table " + self.content.table_name + " created");
-			defer.resolve(self);
-		}, function(err) {
-			defer.reject(err, self);
-		});
-
-	}, timeout || 0);
-
-	return defer.promise;
+	// setTimeout(function() {
+  //
+	// 	http.post(self.url + '/catalog/' + self.catalog.id + "/schema/" + utils._fixedEncodeURIComponent(self.schema.name) + "/table", self.content).then(function(response) {
+	// 		self.content = response.data;
+	// 		self.name = self.content.table_name;
+	// 		console.log("Table " + self.content.table_name + " created");
+	// 		defer.resolve(self);
+	// 	}, function(err) {
+	// 		defer.reject(err, self);
+	// 	});
+  //
+	// }, timeout || 0);
+  //
+	// return defer.promise;
+	return this.content;
 };
 
 /**


### PR DESCRIPTION
This PR will add bulk schema and foreignkey creation. I updated the readme and also one of the demos on how to use this bulk api. We might want to change its name (`createSchemasAndEntities`). The difference between this new function and what we had (`setup` or `importData`) is that those old function would just accept one schema and this new one accept multiple schemas.

Also this new function does not have the option of updating an existing schema since it wasn't used in the test framework and would just make the code messier. 