### PR TITLE
sequentially run POST/PUT requests

### DIFF
--- a/model/catalog.js
+++ b/model/catalog.js
@@ -53,23 +53,21 @@ Catalog.prototype.addACLs = function(acls) {
  * An asynchronous method that returns a promise. If fulfilled, it adds the acls for the catalog.
  */
 Catalog.addACLs = function(url, id, acls) {
-	var defer = Q.defer();
-	if (!id) return defer.reject("No Id set : addACL catalog function"), defer.promise;
-	if (!acls || acls.length == 0) defer.resolve();
+  return new Promise(function (resolve, reject) {
+    if (typeof acls != 'object' || !acls) return resolve();
+    if (!id) return reject("No Id set : addACL catalog function");
 
-	var promises = [];
+    var aclKeys = Object.keys(acls);
+    var next = function () {
+        if (aclKeys.length === 0) return resolve();
 
-	for (var acl in acls) {
-		promises.push(Catalog.addACL(url, id, acl, acls[acl]));
-	}
-
-	Q.all(promises).then(function() {
-		defer.resolve();
-	}, function(err) {
-		defer.reject(err);
-	});
-
-	return defer.promise;
+        var aclKey = aclKeys.shift();
+        Catalog.addACL(url, id, aclKey, acls[aclKey]).then(next).catch(function (err) {
+          reject(err);
+        });
+    }
+    next();
+  });
 };
 
 /**


### PR DESCRIPTION
Since we are not sending POST/PUT requests in sequence, ermrest throws a lot of 503s which can slow the server down.

In this PR, I serialized acl and entity creation steps while creating a catalog. We assumed that calling a function that creates a promise won't run the actual promise until we call `.then` or `.all` on the returned promise. That assumption is completely wrong and Javascript will run the code sequentially, and therefore will run the http requests as soon as it sees the code. So just calling `.all` on the array of returned promise won't solve this issue. I had to make sure to call the functions sequentially after the previous promise is resolved.

In the following example, assume that we have an array of "value"s and we want to call the "asyncFn" for these values sequentially (`asyncFn(values[i])` will return a promise).

```javascript

// sequentially call the asyncFn with different values and return a promise
function runSeq(values) {
  return new Promise (resolve, reject) {
    var next = function () {
      // all values are processed, resolve the promise
      if (values.length === 0) return resolve();
    
      // get the first value
      var value = values.shift();

      // run them sequentially
      asyncFn(value).then(next).catch(function (err) {
        // reject the whole promise
        return reject(err);
      });
    };
    
     // run 
     next();
  };
}
```

related issue: #16 