### PR TITLE
catalog addAnnotations

### DIFF
--- a/import.js
+++ b/import.js
@@ -413,39 +413,40 @@ var removeTables = function(defer, catalogId, schemaName) {
  * @param {catalog}
  */
 var createCatalog = function(catalog) {
-	var defer = Q.defer();
-	var isNew = true;
-	var acls = config.catalog.acls;
-	var hasValidACLs = (typeof acls === "object") && (acls.constructor === Object)  && Object.keys(acls).length !== 0;
+    var defer = Q.defer();
+    var isNew = true;
+    var annotations = config.catalog.annotations;
+    var acls = config.catalog.acls;
 
-	if (!catalog) {
-		defer.resolve();
-	} else if (catalog.id && !config.catalog.acls) {
-		console.log("Catalog with id " + catalog.id + " already exists.");
-		defer.resolve();
-	} else {
-		if (catalog.id) isNew = false;
-		catalog.create().then(function() {
+    if (!catalog) {
+        defer.resolve();
+    } else if (catalog.id && !config.catalog.acls) {
+        console.log("Catalog with id " + catalog.id + " already exists.");
+        defer.resolve();
+    } else {
+        if (catalog.id) isNew = false;
+        catalog.create().then(function() {
 
-			if (isNew) console.log("Catalog created with id " + catalog.id);
-			else console.log("Catalog with id " + catalog.id + " already exists.");
+            if (isNew) console.log("Catalog created with id " + catalog.id);
+            else console.log("Catalog with id " + catalog.id + " already exists.");
 
-			if (hasValidACLs) {
-				console.log("Updating catalog ACLs...");
-				return catalog.addACLs(acls);
-			}
-			defer.resolve();
-		}).then(function() {
-			if (hasValidACLs) {
-				console.log("ACLS added: " + JSON.stringify(acls));
-			}
-			defer.resolve();
-		}, function(err) {
-			defer.reject(err);
-		});
-	}
+            console.log("Creating catalog annotations...");
+            return catalog.addAnnotations(annotations);
+        }).then(function () {
+            console.log("Annotations added");
 
-	return defer.promise;
+            console.log("Updating catalog ACLs...");
+            return catalog.addACLs(acls);
+        }).then(function(message) {
+            console.log(message || "ACLS added: " + JSON.stringify(acls));
+
+            defer.resolve();
+        }, function(err) {
+            defer.reject(err);
+        });
+    }
+
+    return defer.promise;
 };
 
 /**
@@ -688,7 +689,6 @@ exports.createSchemasAndEntities = function (settings) {
   // want to consider removing this and passing it to functions that need it.
   config = settings.setup;
   config.url = settings.url || 'https://dev.isrd.isi.edu/ermrest';
-
   // other parts of the existing code rely on this object
   if (!config.catalog) {
     config.catalog = {};

--- a/import.js
+++ b/import.js
@@ -420,7 +420,7 @@ var createCatalog = function(catalog) {
 
     if (!catalog) {
         defer.resolve();
-    } else if (catalog.id && !config.catalog.acls) {
+    } else if (catalog.id && !config.catalog.acls && !config.catalog.annotations) {
         console.log("Catalog with id " + catalog.id + " already exists.");
         defer.resolve();
     } else {

--- a/import.js
+++ b/import.js
@@ -432,8 +432,8 @@ var createCatalog = function(catalog) {
 
             console.log("Creating catalog annotations...");
             return catalog.addAnnotations(annotations);
-        }).then(function () {
-            console.log("Annotations added");
+        }).then(function (message) {
+            console.log(message || "Annotations added");
 
             console.log("Updating catalog ACLs...");
             return catalog.addACLs(acls);

--- a/model/catalog.js
+++ b/model/catalog.js
@@ -57,39 +57,13 @@ Catalog.addAnnotations = function(url, id, annotations) {
     return new Promise(function (resolve, reject) {
         if (typeof annotations != 'object' || !annotations) return resolve("No annotations to add");
 
-        var keys = Object.keys(annotations);
-        var next = function () {
-            if (keys.length === 0) return resolve();
-
-            var key = keys.shift();
-            Catalog.addAnnotation(url, id, key, annotations[key]).then(next).catch(function (err) {
-                reject(err);
-            });
-        }
-        next();
+        http.put(url + '/catalog/' + id + "/annotation/", annotations).then(function(response) {
+            resolve();
+        }, function(err) {
+            reject(err);
+        });
     });
 }
-
-/**
- * @param {string} key - the key of the annotation
- * @param {Object} value - object containing the annotation definition (will be sent to ermret without any change).
- * @returns {Promise} Returns a promise.
- * @desc
- * An asynchronous method that returns a promise. If fulfilled, it adds the acl for the catalog.
- */
-Catalog.addAnnotation = function(url, id, key, value) {
-    var defer = Q.defer();
-    if (!id || (typeof key !== 'string')) return defer.reject("No Id or Annotation set : addAnnotation catalog function"), defer.promise;
-
-    console.log("value: ", value);
-    http.put(url + '/catalog/' + id + "/annotation/" + utils._fixedEncodeURIComponent(key), value).then(function(response) {
-        defer.resolve();
-    }, function(err) {
-        defer.reject(err);
-    });
-
-    return defer.promise;
-};
 
 Catalog.prototype.addACLs = function(acls) {
     return Catalog.addACLs(this.url, this.id, acls);

--- a/model/catalog.js
+++ b/model/catalog.js
@@ -55,7 +55,7 @@ Catalog.prototype.addAnnotations = function(annotations) {
  */
 Catalog.addAnnotations = function(url, id, annotations) {
     return new Promise(function (resolve, reject) {
-        if (typeof annotations != 'object' || !annotations) return resolve();
+        if (typeof annotations != 'object' || !annotations) return resolve("No annotations to add");
 
         var keys = Object.keys(annotations);
         var next = function () {


### PR DESCRIPTION
This PR is to add functionality to be able to add annotations at the catalog level. I refactored `createCatalog` in `import.js` to always call `addACLs` because the logic to return if none were available is already written into the catalog functionality.